### PR TITLE
Detect fixations on area of interest

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -30,7 +30,7 @@ TRIALS = 5
 # used in libscreen, for the *_display functions. The values may be adjusted,
 # but not the constant's names
 SCREENNR = 0 # number of the screen used for displaying experiment
-DISPTYPE = 'pygame' # either 'psychopy' or 'pygame'
+DISPTYPE = 'psychopy' # either 'psychopy' or 'pygame'
 DISPSIZE = (1920,1080) # canvas size
 SCREENSIZE = (34.5, 19.7) # physical display size in cm
 MOUSEVISIBLE = False # mouse visibility

--- a/experiment.py
+++ b/experiment.py
@@ -1,12 +1,13 @@
 #! /usr/bin/python3
 
 import constants
-import random
+import pygaze
 from pygaze import libscreen
 from pygaze import libtime
 from pygaze import liblog
 from pygaze import libinput
 from pygaze import eyetracker
+from psychopy.visual import TextStim
 
 
 ### for testing ###
@@ -31,11 +32,6 @@ print(font.size(" "))
 # 5 letters: 32px height, 70px width
 # 1 letter: 32px, 14px width
 """
-
-### constants ###
-
-# display size in pixels
-DISPSIZE = (1920, 1080)
 
 
 ### experiment setup ###
@@ -90,7 +86,9 @@ for trialnr, stimulus in enumerate(stimuli):
 
     # show stimulus
     stimulus_screen = libscreen.Screen()
-    stimulus_screen.draw_text(text=stimulus, fontsize=24)
+    textstim = TextStim(pygaze.expdisplay, text=stimulus, font="mono", height=24, color="black", wrapWidth=constants.DISPSIZE[0])
+    stimulus_screen.screen.append(textstim)
+    # stimulus_screen.draw_text(text=stimulus, fontsize=24)
     stimulus_screen.draw_fixation(fixtype='cross', pos=(1840, 1000), pw=3) # bottom right, look at it to finish reading sentence
     disp.fill(stimulus_screen)
     disp.show()

--- a/experiment.py
+++ b/experiment.py
@@ -1,14 +1,16 @@
 #! /usr/bin/python3
 
-import constants
 import pygaze
 from pygaze import libscreen
 from pygaze import libtime
 from pygaze import liblog
 from pygaze import libinput
 from pygaze import eyetracker
-from psychopy.visual import TextBox2
+from psychopy.visual.textbox2 import TextBox2, allFonts
 from psychopy.visual.rect import Rect
+
+
+allFonts.addFontDirectory("fonts")
 
 
 class Stimulus:
@@ -98,7 +100,7 @@ for trialnr, stimulus in enumerate(stimuli):
 
     # show stimulus
     stimulus_screen = libscreen.Screen()
-    textbox = TextBox2(pygaze.expdisplay, text=stimulus.text, font="sans-serif", letterHeight=24, color="black", size=(constants.DISPSIZE[0], None))
+    textbox = TextBox2(pygaze.expdisplay, text=stimulus.text, font="Roboto Mono", letterHeight=24, color="black", size=(None, None))
     if stimulus.chars_of_interest is not None:
         coi_start = stimulus.chars_of_interest[0]
         coi_end = stimulus.chars_of_interest[1]

--- a/experiment.py
+++ b/experiment.py
@@ -9,6 +9,7 @@ from pygaze import liblog
 from pygaze import libinput
 from pygaze import eyetracker
 from pygaze.plugins.aoi import AOI
+from psychopy import event
 from psychopy.visual.textbox2 import TextBox2, allFonts
 from psychopy.visual.rect import Rect
 
@@ -125,7 +126,6 @@ for trialnr, stimulus in enumerate(stimuli):
         aoi = None
 
     stimulus_screen.screen.append(textbox)
-    stimulus_screen.draw_fixation(fixtype='cross', pos=(1840, 1000), pw=3) # bottom right, look at it to finish reading sentence
     disp.fill(stimulus_screen)
     disp.show()
 
@@ -144,11 +144,14 @@ for trialnr, stimulus in enumerate(stimuli):
         ))
 
         # the person only needs to look approximately into the corner, so it counts 100 pixels around as well
-        if endpos[0] > 1740 and endpos[1] > 900:
+        space_pressed = False
+        for key in event.getKeys('space'):
+            if key == 'space':
+                space_pressed = True
+                event.clearEvents()
+                break
+        if space_pressed:
             break
-        # TODO: I can't figure out how to escape the loop by pressing the button, so I'll just go back to looking in a corner
-        # the bottom right to finish. TODO: Fix the instruction text if we keep it like that
-        # response, presstime = keyboard.get_key(timeout=1)
 
     tracker.stop_recording()
 

--- a/experiment.py
+++ b/experiment.py
@@ -110,8 +110,8 @@ for trialnr, stimulus in enumerate(stimuli):
     if stimulus.chars_of_interest is not None:
         coi_start = stimulus.chars_of_interest[0]
         coi_end = stimulus.chars_of_interest[1]
-        aoi_top_left = textbox.verticesPix[coi_start * 4 + 1]
-        aoi_bottom_right = textbox.verticesPix[coi_end * 4 - 1]
+        aoi_top_left = textbox.verticesPix[coi_start * 4 + 1] + (-5, -5)
+        aoi_bottom_right = textbox.verticesPix[coi_end * 4 - 1] + (5, 5)
         aoi_width = aoi_bottom_right[0] - aoi_top_left[0]
         aoi_height = aoi_bottom_right[1] - aoi_top_left[1]
         aoi_center = (aoi_top_left + aoi_bottom_right) / 2
@@ -128,6 +128,7 @@ for trialnr, stimulus in enumerate(stimuli):
     stimulus_screen.screen.append(textbox)
     disp.fill(stimulus_screen)
     disp.show()
+    event.clearEvents()
 
     response = None
     while not response:
@@ -148,13 +149,9 @@ for trialnr, stimulus in enumerate(stimuli):
         log.write([datetime.now().isoformat(), trialnr, stimulus.text, fixation_start_time, fixation_end_time, startpos, endpos, aoi_start, aoi_end])
 
         # the person only needs to look approximately into the corner, so it counts 100 pixels around as well
-        space_pressed = False
-        for key in event.getKeys('space'):
-            if key == 'space':
-                space_pressed = True
-                event.clearEvents()
-                break
-        if space_pressed:
+        if 'space' in event.getKeys():
+            space_pressed = True
+            event.clearEvents()
             break
 
     tracker.stop_recording()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+git://github.com/esdalmaijer/PyGaze@5732d12
 PsychoPy==2021.1.3
+pygame==2.0.1
 wxPython==4.1.1
 numpy==1.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+git://github.com/esdalmaijer/PyGaze@5732d12
-pygame==2.0.1
+PsychoPy==2021.1.3
+wxPython==4.1.1
 numpy==1.20.1


### PR DESCRIPTION
- Switch to PsychoPy, use `TextBox2` for stimuli (allows non-monospaced fonts and exposes glyph positions)
- Introduces a `Stimulus` class to mark characters of interest
- Calculates and visualized the area of interest based on glyph positions
- Detects and logs fixations on area of interest
- Uses keyboard press to continue to next stimulus (instead of fixation point)

TODO:
- [ ] For some uppercase glyphs, the glyph area seems to be too small
- [ ] AOI probably needs to be bigger anyway
- [ ] Switch to a non-monospace font?
- [ ] Remove AOI visualization when we're sure it works well